### PR TITLE
Update vbac.wsf

### DIFF
--- a/vbac.wsf
+++ b/vbac.wsf
@@ -867,7 +867,7 @@ Access.prototype.compact = function(dbPath) {
         }
         return undefined;
     })();
-
+    
     var tempPath = (function(dbPath) {
         var d = fso.GetParentFolderName(dbPath);
         var b = fso.GetBaseName(dbPath);


### PR DESCRIPTION
When binback option using, if bin directory is not exist then error occurs in "fso.CopyFile".
Coping file from "conf.bin" directory, so do only when "conf.bin" directory exists.
