### PR TITLE
Update vbac.wsf

### DIFF
--- a/vbac.wsf
+++ b/vbac.wsf
@@ -867,6 +867,10 @@ Access.prototype.compact = function(dbPath) {
         }
         return undefined;
     })();
+    if (engine === undefined) {
+        println("! Compact: Do nothing, because cannot make DAO.DBEngine object.");
+        return;
+    }
     
     var tempPath = (function(dbPath) {
         var d = fso.GetParentFolderName(dbPath);


### PR DESCRIPTION
When dbcompact option useing, if cannot make DAO.DBEngine object then object reference error occurs.
"engine" is defined at line 861, but return undefined when cannot make.
So if "engine" is undefined then don't compact.
