### PR TITLE
Add Filter2

### DIFF
--- a/src/Ariawase.xlsm/Core.bas
+++ b/src/Ariawase.xlsm/Core.bas
@@ -1150,3 +1150,18 @@ Public Function CreateStdRegProv() As Object
     Dim wmiSrv As Object: Set wmiSrv = Wmi.ConnectServer(, "root\default")
     Set CreateStdRegProv = wmiSrv.Get("StdRegProv")
 End Function
+
+Public Function Filter2(ByVal arr As Variant, ByVal ptrnFind As String, Optional ByVal include As Boolean = True) As Variant
+    If Not IsArray(arr) Then Err.Raise 13
+    If include Then ptrnFind = "^.*" & ptrnFind & ".*$"
+    
+    Dim v As Variant, arrx As New ArrayEx
+    For Each v In arr
+        If UBound(ReMatch(v, ptrnFind)) <> -1 Then arrx.AddVal ReMatch(v, ptrnFind)
+    Next v
+    
+    Select Case UBound(arrx.ToArray)
+        Case Is = -1:   Filter2 = Array(Array(vbNullString))
+        Case Else:      Filter2 = arrx.ToArray
+    End Select
+End Function


### PR DESCRIPTION
Summary
---
`Filter2` is the functions that can be filtered by regular expressions for the elements of the array.

Usage
---
```vb
Option Explicit

Sub SampleFilter2()
    
    Dim arr As Variant: arr = Array("abc123", "def", 123)
    
    Debug.Print Dump(Filter2(arr, "1?3"))
    Debug.Print Dump(Filter2(arr, "zzz"))
    
End Sub
```
Result
---
```vb
Array(Array("abc123"), Array("123"))
Array(Array(""))
```

Test Code
---
```vb
' Assert.RunTestOf New Filter2Test

Public Sub Filter2_Test()
    
    Dim str1 As String: str1 = "abc def ghi"
    Dim str2 As String: str2 = "ghi jkl mno"
    Dim str3 As String: str3 = "123 abc 345"
    
    Assert.AreEqualArr Array("abc def ghi"), Filter2(Array(str1, str2), "g?i")(0)
    Assert.AreEqualArr Array("ghi jkl mno"), Filter2(Array(str1, str2), "g?i")(1)
    Assert.AreEqualArr Array("123"), Filter2(Array(str1, str3), "\d\d\d", False)(0)
    Assert.AreEqualArr Array(vbNullString), Filter2(Array(str3), "zzz")(0)
    
End Sub
```

Result
---
```vb
----------------------------------------------------------------------------
Filter2Test
----------------------------------------------------------------------------
+ Filter2_Test
============================================================================
1 succeeded, 0 failed, took 0.02 seconds.
```